### PR TITLE
fix(read_attribute): make block hash parameter optional

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -36,7 +36,7 @@ pub trait PeaqStorageApi<BlockHash, AccountId> {
         &self,
         did_account: AccountId,
         item_type: Bytes,
-        at: BlockHash,
+        at: Option<BlockHash>,
     ) -> RpcResult<Option<StorageRpcResult>>;
 }
 
@@ -81,10 +81,11 @@ where
         &self,
         did_account: AccountId,
         item_type: Bytes,
-        at: <Block as BlockT>::Hash,
+        at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<Option<StorageRpcResult>> {
         let api = self.client.runtime_api();
-        api.read(at, did_account, item_type.to_vec())
+        let block_hash = at.unwrap_or_else(|| self.client.info().best_hash);
+        api.read(block_hash, did_account, item_type.to_vec())
             .map(|o| o.map(StorageRpcResult::from))
             .map_err(|err| internal_err(err.to_string()))
     }


### PR DESCRIPTION
This PR is fixing the error where we cannot call rpc to read an attribute. This was happening because the parameter at that was referring to the block hash was not optional and so was failing if we didn't provided it. This was not happening on the different tests that we have because it was an issue about rpc only.